### PR TITLE
Add favorites endpoint

### DIFF
--- a/datasources/conjugation.js
+++ b/datasources/conjugation.js
@@ -55,7 +55,9 @@ class ConjugationAPI extends DataSource {
         favorites.forEach(fav => {
            const conjugation = conjugator.conjugate_one(stem, regular, isAdj, fav.honorific, fav.conjugationName);
 
-           data.push(ConjugationAPI.conjugationReducer(conjugation));
+           if(conjugation) {
+               data.push(ConjugationAPI.conjugationReducer(conjugation));
+           }
         });
 
         return data;

--- a/datasources/conjugation.js
+++ b/datasources/conjugation.js
@@ -18,7 +18,7 @@ class ConjugationAPI extends DataSource {
         this.context = config.context;
     }
 
-    fetchConjugations(stem, isAdj,honorific, regular, conjugationNames){
+    fetchConjugations(stem, isAdj, honorific, regular, conjugationNames){
         if(regular === null || regular === undefined) {
             // returns either 'regular verb' or type of irregular
             regular = conjugator.verb_type(stem, false) === 'regular verb';
@@ -31,7 +31,7 @@ class ConjugationAPI extends DataSource {
         }
 
         let  data = [];
-        conjugator.conjugate(stem,regular,isAdj,honorific, conjugations => {
+        conjugator.conjugate(stem, regular, isAdj, honorific, conjugations => {
             conjugations.forEach( c =>{
                 let conjugation = ConjugationAPI.conjugationReducer(c);
                 // If a list of conjugations was provided, check if this conjugation is part of the list
@@ -42,6 +42,22 @@ class ConjugationAPI extends DataSource {
                 }
             });
         });
+        return data;
+    }
+
+    fetchFavorites(stem, isAdj, regular, favorites) {
+        if(regular === null || regular === undefined) {
+            // returns either 'regular verb' or type of irregular
+            regular = conjugator.verb_type(stem, false) === 'regular verb';
+        }
+
+        const data = [];
+        favorites.forEach(fav => {
+           const conjugation = conjugator.conjugate_one(stem, regular, isAdj, fav.honorific, fav.conjugationName);
+
+           data.push(ConjugationAPI.conjugationReducer(conjugation));
+        });
+
         return data;
     }
 

--- a/korean/conjugator.js
+++ b/korean/conjugator.js
@@ -504,6 +504,37 @@ conjugator.conjugate = function(infinitive, regular, isAdj, honorific, callback)
     callback(conjugations);
 };
 
+conjugator.conjugate_one = function(infinitive, regular, isAdj, honorific, name) {
+    let conjugation = name.replace(/ /g,'_');
+    if(honorific) {
+        conjugation += '_honorific';
+    }
+
+    conjugator.reasons.length = 0;
+
+    const r = {};
+    r.conjugated = conjugator[conjugation](infinitive, regular, isAdj, honorific);
+    if(r.conjugated === undefined){ // this conjugation doesn't exist for this word (ex. determiner past for adj.)
+        return;
+    }
+
+    r.infinitive = infinitive + '다';
+    r.conjugation_name = conjugation.replace(/_/g, ' ').replace(' honorific','');
+    r.pronunciation = pronunciation.get_pronunciation(r.conjugated);
+    r.romanized = romanization.romanize(r.pronunciation);
+    r.reasons = [];
+    for (let reason in conjugator.reasons) {
+        r.reasons.push(conjugator.reasons[reason]);
+    }
+
+    r.type = conjugator[conjugation].type;
+    r.tense = conjugator[conjugation].tense;
+    r.speechLevel = conjugator[conjugation].speechLevel;
+    r.honorific = conjugator[conjugation].honorific ? conjugator[conjugation].honorific : false; // should be set to false if undefined
+
+    return r;
+};
+
 conjugator.conjugate_json = function(infinitive, regular, callback) {
     conjugator.conjugate(infinitive, regular, function(result) {
         result.unshift({

--- a/resolvers.js
+++ b/resolvers.js
@@ -7,7 +7,9 @@ module.exports = {
         examples:(_, { id }, { dataSources }) =>
             dataSources.databaseAPI.fetchExamples(id),
         conjugations:(_, {stem, isAdj, honorific, regular, conjugations }, { dataSources }) =>
-            dataSources.conjugationAPI.fetchConjugations(stem,isAdj, honorific, regular, conjugations),
+            dataSources.conjugationAPI.fetchConjugations(stem, isAdj, honorific, regular, conjugations),
+        favorites:(_, {stem, isAdj, regular, favorites }, { dataSources }) =>
+            dataSources.conjugationAPI.fetchFavorites(stem, isAdj, regular, favorites),
         conjugationTypes: (_,{},{ dataSources }) =>
             dataSources.conjugationAPI.fetchConjugationTypes(),
         conjugationNames: (_,{}, { dataSources }) =>

--- a/schema.js
+++ b/schema.js
@@ -5,7 +5,7 @@ const typeDefs = gql`
         entry(id: ID!): Entry
         examples(id: ID!): [Example]!
         conjugations(stem: String!, isAdj: Boolean!, honorific: Boolean!, regular: Boolean, conjugations: [String]): [Conjugation]!
-        favorites(stem: String!, isAdj: Boolean!, regular: Boolean, favorites: [Favorite]!): [Conjugation]!
+        favorites(stem: String!, isAdj: Boolean!, regular: Boolean, favorites: [FavInput]!): [Conjugation]!
         conjugationTypes: [String]!
         conjugationNames: [String]!
         search(query: String!, cursor: Int): Result!
@@ -62,7 +62,7 @@ const typeDefs = gql`
         reasons: [String]!
     }
     
-    input Favorite {
+    input FavInput {
         name: String!
         conjugationName: String!
         honorific: Boolean!

--- a/schema.js
+++ b/schema.js
@@ -5,6 +5,7 @@ const typeDefs = gql`
         entry(id: ID!): Entry
         examples(id: ID!): [Example]!
         conjugations(stem: String!, isAdj: Boolean!, honorific: Boolean!, regular: Boolean, conjugations: [String]): [Conjugation]!
+        favorites(stem: String!, isAdj: Boolean!, regular: Boolean, favorites: [Favorite]!): [Conjugation]!
         conjugationTypes: [String]!
         conjugationNames: [String]!
         search(query: String!, cursor: Int): Result!
@@ -59,6 +60,12 @@ const typeDefs = gql`
         pronunciation: String!
         romanization: String!
         reasons: [String]!
+    }
+    
+    input Favorite {
+        name: String!
+        conjugationName: String!
+        honorific: Boolean!
     }
 `;
 

--- a/tests/conjugator.test.js
+++ b/tests/conjugator.test.js
@@ -63,6 +63,42 @@ test('verb type functions', async () => {
     assert.equal(conjugator.verb_type('가다'), 'regular verb');
 });
 
+test('conjugation_one function', () => {
+    // regular
+    let conjugation = conjugator.conjugate_one('가다', false, false, false,
+        'declarative present informal high');
+
+    expect(conjugation.conjugated).toEqual('가요');
+    expect(conjugation.conjugation_name).toEqual('declarative present informal high');
+    expect(conjugation.pronunciation).toEqual('가요');
+    expect(conjugation.romanized).toEqual('gah-yoh');
+    expect(conjugation.type).toEqual('declarative present');
+    expect(conjugation.tense).toEqual('present');
+    expect(conjugation.speechLevel).toEqual('informal high');
+    expect(conjugation.honorific).toBeFalsy();
+    expect(conjugation.reasons).toEqual(['vowel contraction [ㅏ ㅏ -> ㅏ] (가 + 아 -> 가)', 'join (가 + 요 -> 가요)']);
+
+    conjugation = conjugator.conjugate_one('가다', false, false, true,
+        'declarative future informal high');
+
+    // honorific
+    expect(conjugation.conjugated).toEqual('가실 거예요');
+    expect(conjugation.conjugation_name).toEqual('declarative future informal high');
+    expect(conjugation.pronunciation).toEqual('가실 거예요');
+    expect(conjugation.romanized).toEqual('gah-sheel- -guh-yae-yoh');
+    expect(conjugation.type).toEqual('declarative future');
+    expect(conjugation.tense).toEqual('future');
+    expect(conjugation.speechLevel).toEqual('informal high');
+    expect(conjugation.honorific).toBeTruthy();
+    expect(conjugation.reasons).toEqual(['join (가 + 시 -> 가시)', 'borrow padchim (가시 + 을 -> 가실)', 'join (가실 +  거예요 -> 가실 거예요)']);
+
+    // Determiner past doesn't exist for adjectives
+    conjugation = conjugator.conjugate_one('춥다', false, true, false,
+        'determiner past');
+
+    expect(conjugation).toBeUndefined();
+});
+
 test('reasons', () => {
     // Declarative present
     conjugator.reasons.length = 0;


### PR DESCRIPTION
Closes [this issue](https://github.com/Ninjaman494/Hanji-Android-App/issues/48) on the Android app repo. Built a new endpoint that uses a list of favorites to build a list of conjugations. 