### PR TITLE
Use object list in conjugations query

### DIFF
--- a/src/features/conjugation/__tests__/conjugationsSnapshot.ts
+++ b/src/features/conjugation/__tests__/conjugationsSnapshot.ts
@@ -1,3 +1,39 @@
+export const SPECIFIC_CONJUGATIONS = [
+  {
+    name: 'connective if',
+    conjugation: '가면',
+    type: 'connective',
+    tense: 'none',
+    speechLevel: 'none',
+    honorific: false,
+    pronunciation: '가면',
+    romanization: 'gah-myuhn',
+    reasons: ['join (가 + 면 -> 가면)'],
+  },
+  {
+    name: 'declarative present informal high',
+    conjugation: '가세요',
+    type: 'declarative present',
+    tense: 'present',
+    speechLevel: 'informal high',
+    honorific: true,
+    pronunciation: '가세요',
+    romanization: 'gah-sae-yoh',
+    reasons: ['join (가 + 세요 -> 가세요)'],
+  },
+  {
+    name: 'propositive informal low',
+    conjugation: '가',
+    type: 'propositive',
+    tense: 'present',
+    speechLevel: 'informal low',
+    honorific: false,
+    pronunciation: '가',
+    romanization: 'gah',
+    reasons: ['vowel contraction [ㅏ ㅏ -> ㅏ] (가 + 아 -> 가)'],
+  },
+];
+
 export const CONJUGATIONS = [
   {
     name: 'connective if',
@@ -482,6 +518,47 @@ export const CONJUGATIONS = [
     reasons: ['join (가 + 겠습니다 -> 가겠습니다)'],
     type: 'suppositive',
     honorific: false,
+  },
+];
+
+/**
+ * The integration version passes through enum
+ * modifications (i.e. `formal low` to `FORMAL_LOW`)
+ * and is what the API returns in production
+ */
+export const SPECIFIC_CONJUGATIONS_INTEGRATION = [
+  {
+    name: 'connective if',
+    conjugation: '가면',
+    type: 'connective',
+    tense: 'NONE',
+    speechLevel: 'NONE',
+    honorific: false,
+    pronunciation: '가면',
+    romanization: 'gah-myuhn',
+    reasons: ['join (가 + 면 -> 가면)'],
+  },
+  {
+    name: 'declarative present informal high',
+    conjugation: '가세요',
+    type: 'declarative present',
+    tense: 'PRESENT',
+    speechLevel: 'INFORMAL_HIGH',
+    honorific: true,
+    pronunciation: '가세요',
+    romanization: 'gah-sae-yoh',
+    reasons: ['join (가 + 세요 -> 가세요)'],
+  },
+  {
+    name: 'propositive informal low',
+    conjugation: '가',
+    type: 'propositive',
+    tense: 'PRESENT',
+    speechLevel: 'INFORMAL_LOW',
+    honorific: false,
+    pronunciation: '가',
+    romanization: 'gah',
+    reasons: ['vowel contraction [ㅏ ㅏ -> ㅏ] (가 + 아 -> 가)'],
   },
 ];
 

--- a/src/features/conjugation/__tests__/integration.test.ts
+++ b/src/features/conjugation/__tests__/integration.test.ts
@@ -6,6 +6,7 @@ import {
   CONJUGATIONS_INTEGRATION,
   CONJUGATION_NAMES,
   CONJUGATION_TYPES,
+  SPECIFIC_CONJUGATIONS_INTEGRATION,
   STEMS,
 } from './conjugationsSnapshot';
 import { executeOperation } from 'tests/utils';
@@ -16,14 +17,14 @@ const server = new ApolloServer({
 });
 
 describe('conjugation feature', () => {
-  it('handles conjugations queries', async () => {
+  describe('conjugations query', () => {
     const query = gql`
       query Conjugations(
         $stem: String!
         $isAdj: Boolean!
         $honorific: Boolean!
         $regular: Boolean
-        $conjugations: [String]
+        $conjugations: [ConjugationInput]
       ) {
         conjugations(
           stem: $stem
@@ -44,16 +45,34 @@ describe('conjugation feature', () => {
         }
       }
     `;
+    it('fetches conjugations', async () => {
+      const { errors, data } = await executeOperation(server, query, {
+        stem: '가다',
+        isAdj: false,
+        honorific: false,
+      });
 
-    const { errors, data } = await executeOperation(server, query, {
-      stem: '가다',
-      isAdj: false,
-      honorific: false,
+      expect(errors).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.conjugations).toEqual(CONJUGATIONS_INTEGRATION);
     });
 
-    expect(errors).toBeUndefined();
-    expect(data).toBeDefined();
-    expect(data.conjugations).toEqual(CONJUGATIONS_INTEGRATION);
+    it('fetches specific conjugations', async () => {
+      const { errors, data } = await executeOperation(server, query, {
+        stem: '가다',
+        isAdj: false,
+        honorific: false,
+        conjugations: [
+          { name: 'connective if', honorific: false },
+          { name: 'declarative present informal high', honorific: true },
+          { name: 'propositive informal low', honorific: false },
+        ],
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.conjugations).toEqual(SPECIFIC_CONJUGATIONS_INTEGRATION);
+    });
   });
 
   it('handles conjugationTypes queries', async () => {

--- a/src/features/conjugation/__tests__/resolvers.test.ts
+++ b/src/features/conjugation/__tests__/resolvers.test.ts
@@ -2,6 +2,7 @@ import {
   CONJUGATIONS,
   CONJUGATION_NAMES,
   CONJUGATION_TYPES,
+  SPECIFIC_CONJUGATIONS,
   STEMS,
 } from './conjugationsSnapshot';
 import resolvers from '../resolvers';
@@ -20,15 +21,10 @@ describe('conjugation resolver', () => {
 
     it('fetches specific conjugations', () => {
       const conjugations = [
-        'connective if',
-        'declarative present informal low',
-        'propositive informal low',
+        { name: 'connective if', honorific: false },
+        { name: 'declarative present informal high', honorific: true },
+        { name: 'propositive informal low', honorific: false },
       ];
-      const expectedConjugations = CONJUGATIONS.reduce(
-        (prev, val) =>
-          conjugations.includes(val.name) ? [...prev, val] : prev,
-        [],
-      );
 
       const response = (resolvers.Query.conjugations as any)(null, {
         stem: '가다',
@@ -37,7 +33,7 @@ describe('conjugation resolver', () => {
         regular: true,
         conjugations,
       });
-      expect(response).toEqual(expectedConjugations);
+      expect(response).toEqual(SPECIFIC_CONJUGATIONS);
     });
 
     it('returns no results when stem is empty', () => {

--- a/src/features/conjugation/resolvers.ts
+++ b/src/features/conjugation/resolvers.ts
@@ -17,11 +17,11 @@ const resolvers: Resolvers = {
 
       // Use favorites' method to get specific conjugations because it's
       // more performant.
-      // TODO - In the future favorites should be merged with conjugations
+      // TODO - Delete favorites feature once enough people have upgraded
       if (!!conjugations) {
-        const conjArgs: FavInput[] = conjugations.map((conjugationName) => ({
-          conjugationName,
-          honorific,
+        const conjArgs: FavInput[] = conjugations.map((c) => ({
+          conjugationName: c.name,
+          honorific: c.honorific,
           regular,
         }));
         return getConjugations(stem, isAdj, regular, conjArgs);

--- a/src/features/conjugation/typeDefs.ts
+++ b/src/features/conjugation/typeDefs.ts
@@ -7,11 +7,16 @@ const typeDef = gql`
       isAdj: Boolean!
       honorific: Boolean!
       regular: Boolean
-      conjugations: [String]
+      conjugations: [ConjugationInput]
     ): [Conjugation]!
     conjugationTypes: [String]!
     conjugationNames: [String]!
     stems(term: String!): [String]!
+  }
+
+  input ConjugationInput {
+    name: String!
+    honorific: Boolean!
   }
 
   type Conjugation {

--- a/src/features/favorite/resolvers.ts
+++ b/src/features/favorite/resolvers.ts
@@ -1,12 +1,12 @@
 import { conjugationReducer } from 'features/utils';
-import { Conjugation, Resolvers, FavInput } from 'generated/graphql';
+import { Conjugation, Resolvers } from 'generated/graphql';
 import conjugator from 'korean/conjugator';
 
 export const getConjugations = (
   stem: string,
   isAdj: boolean,
   regular: boolean,
-  conjugations: FavInput[],
+  conjugations: { conjugationName: string; honorific: boolean }[],
 ) => {
   if (!stem.trim()) return [];
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -43,6 +43,11 @@ export type Conjugation = {
   type: Scalars['String'];
 };
 
+export type ConjugationInput = {
+  honorific: Scalars['Boolean'];
+  name: Scalars['String'];
+};
+
 export type DeviceInfo = {
   brand: Scalars['String'];
   manufacturer: Scalars['String'];
@@ -149,7 +154,7 @@ export type Query = {
 
 
 export type QueryConjugationsArgs = {
-  conjugations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  conjugations?: InputMaybe<Array<InputMaybe<ConjugationInput>>>;
   honorific: Scalars['Boolean'];
   isAdj: Scalars['Boolean'];
   regular?: InputMaybe<Scalars['Boolean']>;
@@ -273,6 +278,7 @@ export type ResolversTypes = {
   BugReportResponse: ResolverTypeWrapper<BugReportResponse>;
   BugReportType: BugReportType;
   Conjugation: ResolverTypeWrapper<Conjugation>;
+  ConjugationInput: ConjugationInput;
   DeviceInfo: DeviceInfo;
   Entry: ResolverTypeWrapper<Entry>;
   EntrySuggestion: ResolverTypeWrapper<EntrySuggestion>;
@@ -298,6 +304,7 @@ export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
   BugReportResponse: BugReportResponse;
   Conjugation: Conjugation;
+  ConjugationInput: ConjugationInput;
   DeviceInfo: DeviceInfo;
   Entry: Entry;
   EntrySuggestion: EntrySuggestion;


### PR DESCRIPTION
Server-side part of [React-Native#106](https://github.com/Ninjaman494/Hanji-React-Native/issues/106). Since the `conjugations` field wasn't being used in any of the RN versions of the app, I updated it to a list of `{name, honorific}` objects. Once the RN app has been updated to use this instead of `favorites`, and enough people have upgraded, we can remove the favorites feature entirely.