### PR TITLE
Created getConjugations query

### DIFF
--- a/src/features/conjugation/__tests__/conjugationsSnapshot.ts
+++ b/src/features/conjugation/__tests__/conjugationsSnapshot.ts
@@ -1,3 +1,80 @@
+export const SPECIFIC_CONJUGATIONS = [
+  {
+    name: 'connective if',
+    conjugation: '가면',
+    type: 'connective',
+    tense: 'none',
+    speechLevel: 'none',
+    honorific: false,
+    pronunciation: '가면',
+    romanization: 'gah-myuhn',
+    reasons: ['join (가 + 면 -> 가면)'],
+  },
+  {
+    name: 'declarative present informal high',
+    conjugation: '가세요',
+    type: 'declarative present',
+    tense: 'present',
+    speechLevel: 'informal high',
+    honorific: true,
+    pronunciation: '가세요',
+    romanization: 'gah-sae-yoh',
+    reasons: ['join (가 + 세요 -> 가세요)'],
+  },
+  {
+    name: 'propositive informal low',
+    conjugation: '가',
+    type: 'propositive',
+    tense: 'present',
+    speechLevel: 'informal low',
+    honorific: false,
+    pronunciation: '가',
+    romanization: 'gah',
+    reasons: ['vowel contraction [ㅏ ㅏ -> ㅏ] (가 + 아 -> 가)'],
+  },
+];
+
+/**
+ * The integration version passes through enum
+ * modifications (i.e. `formal low` to `FORMAL_LOW`)
+ * and is what the API returns in production
+ */
+export const SPECIFIC_CONJUGATIONS_INTEGRATION = [
+  {
+    name: 'connective if',
+    conjugation: '가면',
+    type: 'connective',
+    tense: 'NONE',
+    speechLevel: 'NONE',
+    honorific: false,
+    pronunciation: '가면',
+    romanization: 'gah-myuhn',
+    reasons: ['join (가 + 면 -> 가면)'],
+  },
+  {
+    name: 'declarative present informal high',
+    conjugation: '가세요',
+    type: 'declarative present',
+    tense: 'PRESENT',
+    speechLevel: 'INFORMAL_HIGH',
+    honorific: true,
+    pronunciation: '가세요',
+    romanization: 'gah-sae-yoh',
+    reasons: ['join (가 + 세요 -> 가세요)'],
+  },
+  {
+    name: 'propositive informal low',
+    conjugation: '가',
+    type: 'propositive',
+    tense: 'PRESENT',
+    speechLevel: 'INFORMAL_LOW',
+    honorific: false,
+    pronunciation: '가',
+    romanization: 'gah',
+    reasons: ['vowel contraction [ㅏ ㅏ -> ㅏ] (가 + 아 -> 가)'],
+  },
+];
+
 export const CONJUGATIONS = [
   {
     name: 'connective if',

--- a/src/features/conjugation/__tests__/integration.test.ts
+++ b/src/features/conjugation/__tests__/integration.test.ts
@@ -6,6 +6,7 @@ import {
   CONJUGATIONS_INTEGRATION,
   CONJUGATION_NAMES,
   CONJUGATION_TYPES,
+  SPECIFIC_CONJUGATIONS_INTEGRATION,
   STEMS,
 } from './conjugationsSnapshot';
 import { executeOperation } from 'tests/utils';
@@ -16,6 +17,73 @@ const server = new ApolloServer({
 });
 
 describe('conjugation feature', () => {
+  describe('getConjugations query', () => {
+    it('fetches conjugations', async () => {
+      const query = gql`
+        query GetConjugations($input: ConjugationsInput!) {
+          getConjugations(input: $input) {
+            name
+            conjugation
+            type
+            tense
+            speechLevel
+            honorific
+            pronunciation
+            romanization
+            reasons
+          }
+        }
+      `;
+
+      const { errors, data } = await executeOperation(server, query, {
+        input: {
+          stem: '가다',
+          isAdj: false,
+          honorific: false,
+        },
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.getConjugations).toEqual(CONJUGATIONS_INTEGRATION);
+    });
+
+    it('fetches specific conjugations', async () => {
+      const query = gql`
+        query GetConjugations($input: ConjugationsInput!) {
+          getConjugations(input: $input) {
+            name
+            conjugation
+            type
+            tense
+            speechLevel
+            honorific
+            pronunciation
+            romanization
+            reasons
+          }
+        }
+      `;
+
+      const { errors, data } = await executeOperation(server, query, {
+        input: {
+          stem: '가다',
+          isAdj: false,
+          honorific: false,
+          conjugations: [
+            { name: 'connective if', honorific: false },
+            { name: 'declarative present informal high', honorific: true },
+            { name: 'propositive informal low', honorific: false },
+          ],
+        },
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data).toBeDefined();
+      expect(data.getConjugations).toEqual(SPECIFIC_CONJUGATIONS_INTEGRATION);
+    });
+  });
+
   it('handles conjugations queries', async () => {
     const query = gql`
       query Conjugations(

--- a/src/features/conjugation/__tests__/resolvers.test.ts
+++ b/src/features/conjugation/__tests__/resolvers.test.ts
@@ -2,6 +2,7 @@ import {
   CONJUGATIONS,
   CONJUGATION_NAMES,
   CONJUGATION_TYPES,
+  SPECIFIC_CONJUGATIONS,
   STEMS,
 } from './conjugationsSnapshot';
 import resolvers from '../resolvers';
@@ -49,6 +50,37 @@ describe('conjugation resolver', () => {
       });
 
       expect(response.length).toEqual(0);
+    });
+  });
+
+  describe('getConjugations query', () => {
+    it('fetches conjugations', () => {
+      const response = (resolvers.Query.getConjugations as any)(null, {
+        input: {
+          stem: '가다',
+          isAdj: false,
+          honorific: false,
+          regular: true,
+        },
+      });
+      expect(response).toEqual(CONJUGATIONS);
+    });
+
+    it('fetches specific conjugations', () => {
+      const conjugations = [
+        { name: 'connective if', honorific: false },
+        { name: 'declarative present informal high', honorific: true },
+        { name: 'propositive informal low', honorific: false },
+      ];
+
+      const response = (resolvers.Query.getConjugations as any)(null, {
+        input: {
+          stem: '가다',
+          isAdj: false,
+          conjugations,
+        },
+      });
+      expect(response).toEqual(SPECIFIC_CONJUGATIONS);
     });
   });
 

--- a/src/features/conjugation/resolvers.ts
+++ b/src/features/conjugation/resolvers.ts
@@ -5,39 +5,63 @@ import {
   FavInput,
   Resolvers,
   SpeechLevel,
+  SpecificConjugation,
   Tense,
 } from 'generated/graphql';
 import conjugator from 'korean/conjugator';
 import * as stemmer from 'korean/stemmer';
 
+// TODO - remove conjugations and favorites endpoints when enough people
+// have updated
+const resolveConjugations = (
+  stem: string,
+  isAdj: boolean,
+  honorific: boolean,
+  regular: boolean,
+  conjugations?: SpecificConjugation[],
+) => {
+  if (!stem.trim()) return [];
+
+  // Use favorites' method to get specific conjugations because it's
+  // more performant.
+  if (!!conjugations) {
+    const conjArgs: FavInput[] = conjugations.map(({ name, honorific }) => ({
+      conjugationName: name,
+      honorific,
+    }));
+    return getConjugations(stem, isAdj, regular, conjArgs);
+  }
+
+  if (regular === null || regular === undefined) {
+    // returns either 'regular verb' or type of irregular
+    regular = conjugator.verb_type(stem, false) === 'regular verb';
+  }
+
+  const data: Conjugation[] = [];
+  conjugator.conjugate(stem, regular, isAdj, honorific, (conjugations) =>
+    conjugations.forEach((c) => data.push(conjugationReducer(c))),
+  );
+  return data;
+};
+
 const resolvers: Resolvers = {
   Query: {
-    conjugations: (_, { stem, isAdj, honorific, regular, conjugations }) => {
-      if (!stem.trim()) return [];
-
-      // Use favorites' method to get specific conjugations because it's
-      // more performant.
-      // TODO - In the future favorites should be merged with conjugations
-      if (!!conjugations) {
-        const conjArgs: FavInput[] = conjugations.map((conjugationName) => ({
-          conjugationName,
-          honorific,
-          regular,
-        }));
-        return getConjugations(stem, isAdj, regular, conjArgs);
-      }
-
-      if (regular === null || regular === undefined) {
-        // returns either 'regular verb' or type of irregular
-        regular = conjugator.verb_type(stem, false) === 'regular verb';
-      }
-
-      const data: Conjugation[] = [];
-      conjugator.conjugate(stem, regular, isAdj, honorific, (conjugations) =>
-        conjugations.forEach((c) => data.push(conjugationReducer(c))),
-      );
-      return data;
-    },
+    conjugations: (_, { stem, isAdj, honorific, regular, conjugations }) =>
+      resolveConjugations(
+        stem,
+        isAdj,
+        honorific,
+        regular,
+        conjugations?.map((c) => ({ name: c, honorific })),
+      ),
+    getConjugations: (_, { input }) =>
+      resolveConjugations(
+        input.stem,
+        input.isAdj,
+        input.honorific,
+        input.regular,
+        input.conjugations,
+      ),
     conjugationTypes: () => Array.from(conjugator.getTypes()),
     conjugationNames: () => Array.from(conjugator.getNames()),
     stems: (_, { term }) => {

--- a/src/features/conjugation/typeDefs.ts
+++ b/src/features/conjugation/typeDefs.ts
@@ -9,9 +9,23 @@ const typeDef = gql`
       regular: Boolean
       conjugations: [String]
     ): [Conjugation]!
+    getConjugations(input: ConjugationsInput!): [Conjugation]!
     conjugationTypes: [String]!
     conjugationNames: [String]!
     stems(term: String!): [String]!
+  }
+
+  input ConjugationsInput {
+    stem: String!
+    isAdj: Boolean!
+    honorific: Boolean
+    regular: Boolean
+    conjugations: [SpecificConjugation]
+  }
+
+  input SpecificConjugation {
+    name: String!
+    honorific: Boolean!
   }
 
   type Conjugation {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -43,6 +43,14 @@ export type Conjugation = {
   type: Scalars['String'];
 };
 
+export type ConjugationsInput = {
+  conjugations?: InputMaybe<Array<InputMaybe<SpecificConjugation>>>;
+  honorific?: InputMaybe<Scalars['Boolean']>;
+  isAdj: Scalars['Boolean'];
+  regular?: InputMaybe<Scalars['Boolean']>;
+  stem: Scalars['String'];
+};
+
 export type DeviceInfo = {
   brand: Scalars['String'];
   manufacturer: Scalars['String'];
@@ -142,6 +150,7 @@ export type Query = {
   entries: Array<Maybe<Entry>>;
   entry?: Maybe<Entry>;
   favorites: Array<Maybe<Conjugation>>;
+  getConjugations: Array<Maybe<Conjugation>>;
   search: Result;
   stems: Array<Maybe<Scalars['String']>>;
   wordOfTheDay: Entry;
@@ -175,6 +184,11 @@ export type QueryFavoritesArgs = {
 };
 
 
+export type QueryGetConjugationsArgs = {
+  input: ConjugationsInput;
+};
+
+
 export type QuerySearchArgs = {
   cursor?: InputMaybe<Scalars['Int']>;
   query: Scalars['String'];
@@ -194,6 +208,11 @@ export type Result = {
   __typename?: 'Result';
   cursor?: Maybe<Scalars['Int']>;
   results: Array<Maybe<Entry>>;
+};
+
+export type SpecificConjugation = {
+  honorific: Scalars['Boolean'];
+  name: Scalars['String'];
 };
 
 export { SpeechLevel };
@@ -273,6 +292,7 @@ export type ResolversTypes = {
   BugReportResponse: ResolverTypeWrapper<BugReportResponse>;
   BugReportType: BugReportType;
   Conjugation: ResolverTypeWrapper<Conjugation>;
+  ConjugationsInput: ConjugationsInput;
   DeviceInfo: DeviceInfo;
   Entry: ResolverTypeWrapper<Entry>;
   EntrySuggestion: ResolverTypeWrapper<EntrySuggestion>;
@@ -287,6 +307,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   Question: Question;
   Result: ResolverTypeWrapper<Result>;
+  SpecificConjugation: SpecificConjugation;
   SpeechLevel: SpeechLevel;
   String: ResolverTypeWrapper<Scalars['String']>;
   Tense: Tense;
@@ -298,6 +319,7 @@ export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
   BugReportResponse: BugReportResponse;
   Conjugation: Conjugation;
+  ConjugationsInput: ConjugationsInput;
   DeviceInfo: DeviceInfo;
   Entry: Entry;
   EntrySuggestion: EntrySuggestion;
@@ -312,6 +334,7 @@ export type ResolversParentTypes = {
   Query: {};
   Question: Question;
   Result: Result;
+  SpecificConjugation: SpecificConjugation;
   String: Scalars['String'];
   Upload: Scalars['Upload'];
 };
@@ -394,6 +417,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   entries?: Resolver<Array<Maybe<ResolversTypes['Entry']>>, ParentType, ContextType, RequireFields<QueryEntriesArgs, 'term'>>;
   entry?: Resolver<Maybe<ResolversTypes['Entry']>, ParentType, ContextType, RequireFields<QueryEntryArgs, 'id'>>;
   favorites?: Resolver<Array<Maybe<ResolversTypes['Conjugation']>>, ParentType, ContextType, RequireFields<QueryFavoritesArgs, 'favorites' | 'isAdj' | 'stem'>>;
+  getConjugations?: Resolver<Array<Maybe<ResolversTypes['Conjugation']>>, ParentType, ContextType, RequireFields<QueryGetConjugationsArgs, 'input'>>;
   search?: Resolver<ResolversTypes['Result'], ParentType, ContextType, RequireFields<QuerySearchArgs, 'query'>>;
   stems?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType, RequireFields<QueryStemsArgs, 'term'>>;
   wordOfTheDay?: Resolver<ResolversTypes['Entry'], ParentType, ContextType>;


### PR DESCRIPTION
It turns out that changing one of the arguments in `conjugations` isn't backwards compatible because the types are different. Instead, I created a new endpoint to migrate to. Once everyone's updated to a version of Hanji that uses this endpoint instead of `conjugations` or `favorites`, we can delete both those endpoints.